### PR TITLE
Make trajectory interpolation in OMPL independent of StateSpace setup

### DIFF
--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -367,9 +367,10 @@ void ompl_interface::ModelBasedPlanningContext::interpolateSolution()
   if (ompl_simple_setup_->haveSolutionPath())
   {
     og::PathGeometric& pg = ompl_simple_setup_->getSolutionPath();
-    int waypoint_count = max_solution_segment_length_ > std::numeric_limits<double>::epsilon() ?
-      std::max((unsigned int)floor(0.5 + pg.length() / max_solution_segment_length_), minimum_waypoint_count_)) :
-      minimum_waypoint_count_;
+    const unsigned int waypoint_count =
+        max_solution_segment_length_ > std::numeric_limits<double>::epsilon() ?
+            std::max<unsigned int>(std::ceil(pg.length() / max_solution_segment_length_, minimum_waypoint_count_)) :
+            minimum_waypoint_count_;
     pg.interpolate(waypoint_count);
   }
 }

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -367,26 +367,10 @@ void ompl_interface::ModelBasedPlanningContext::interpolateSolution()
   if (ompl_simple_setup_->haveSolutionPath())
   {
     og::PathGeometric& pg = ompl_simple_setup_->getSolutionPath();
-
-    // Find the number of states that will be in the interpolated solution.
-    // This is what interpolate() does internally.
-    int eventual_states = 1;
-    std::vector<ompl::base::State*> states = pg.getStates();
-    for (size_t i = 0; i < states.size() - 1; i++)
-    {
-      eventual_states += ompl_simple_setup_->getStateSpace()->validSegmentCount(states[i], states[i + 1]);
-    }
-
-    if (eventual_states < minimum_waypoint_count_)
-    {
-      // If that's not enough states, use the minimum amount instead.
-      pg.interpolate(minimum_waypoint_count_);
-    }
-    else
-    {
-      // Interpolate the path to have as the exact states that are checked when validating motions.
-      pg.interpolate();
-    }
+    int waypoint_count = max_solution_segment_length_ > std::numeric_limits<double>::epsilon() ?
+      std::max((unsigned int)floor(0.5 + pg.length() / max_solution_segment_length_), minimum_waypoint_count_)) :
+      minimum_waypoint_count_;
+    pg.interpolate(waypoint_count);
   }
 }
 


### PR DESCRIPTION
### Description

Motion validation resolution should not affect interpolation of resulting trajectory, since it can lead to excessive amount of waypoints.
So `ompl_interface::ModelBasedPlanningContext::interpolateSolution()` is reverted to use only `max_solution_segment_length_` and `minimum_waypoint_count_` to calculate minimum number of states in solution.

Same problem exists in  `melodic-devel` branch.

### Checklist
- [x] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [x] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
